### PR TITLE
[BUILD] use the whole eclipse dir for build

### DIFF
--- a/src/setup_ci_build.sh
+++ b/src/setup_ci_build.sh
@@ -6,7 +6,7 @@ mkdir -p $TOOLS_DIR
 
 prepare_env
 
-install_eclipse_plugins $ECLIPSE_HOME
+install_eclipse $ECLIPSE_HOME
 install_intellij $INTELLIJ_HOME
 apk add --no-cache npm
 


### PR DESCRIPTION
The whole eclipse installation is required for gradle,
because the eclipse dir is interpreted as p2 repo and
parsed in order to convert it to a maven repo