### PR TITLE
[BUILD] Update to Intellij 2018.2.6

### DIFF
--- a/src/uri_env.sh
+++ b/src/uri_env.sh
@@ -1,4 +1,4 @@
 export ECLIPSE_URI="https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/neon/3/eclipse-java-neon-3-linux-gtk-x86_64.tar.gz&mirror_id=1" \
-       INTELLIJ_URI="https://download.jetbrains.com/idea/ideaIC-2017.3.5-no-jdk.tar.gz" \
+       INTELLIJ_URI="https://download.jetbrains.com/idea/ideaIC-2018.2.6-no-jdk.tar.gz" \
        GRADLE_URI="https://services.gradle.org/distributions/gradle-4.10.1-bin.zip" \
        NODE_URI="https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.gz"


### PR DESCRIPTION
This updated is needed to build saros-project/saros#343. The problem is
that the new logic relies on the fact that IntelliJ listeners now have
default implementations. In the currently used version, the default
implementation for the methods of FileEditorManagerListener.Before()
does not seem to exist yet. This causes the build to fail.

Even though IntelliJ 2017.2.7 and 2018.3 have already been released,
this patch still uses 2018.2.6 as this is the latest version our plugin
has been tested on.