### PR TITLE
[DOC] How to publish an image with Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,35 @@
 This repository contains all files and scripts to create the docker images which are required for the CI jobs.
 In order to work with docker a docker client installation is required.
 
-## Versioning
-The version/tag number is only incremented if the adjusted images would break the current Travis CI build.
+## Create a new image tag in Docker Hub
+Our images are hosted by [Docker Hub](https://hub.docker.com/u/saros).
+Each new pull request triggers a new image build within Docker Hub, but the result of the build is not tagged and cannot be used.
+Docker Hub maps the git/GitHub tags to docker tags. Therefore you have to create a [new git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) in order to create a new tagged image.
 
-## Provided images
+If you want to publish a new image you have to:
+* Merge your pull request into master
+* Create a new git tag with:
+  * open bash
+  * change directory to local `saros-project/dockerfiles` repository
+  * `git tag -a <tag name> <commit to be tagged> -m <tag message>`
+  * `git push --tags origin master`
+
+## Build images locally
+
+### Prerequisites
+* Local installation of docker
+
+### Build all images
+* Simply call the script `build.sh` to build and tag the images in your local registry.
+
+### Troubleshooting
+The build process should fail if a command of the corresponding setup bash script fails. There are two possible reasons why this could happen:
+* A bug in a Dockerfile or script
+* One of the following external dependencies is not available:
+  * A docker image which is used as the basis for our images
+  * A uri which is defined in `src/uri_env.sh` is not reachable
+
+## Explanation of provided images
 The following images are provided:
  * Saros test, build and stf testing master image (Dockerfile: `Dockerfile.ci_build`)
  * Gradle alpine image, which is the basis of the previous images (Dockerfile: `Dockerfile.gradle_alpine`).
@@ -35,34 +60,3 @@ Therefore the image contains only a few tools which are required for the executi
 This image is used during the STF test process to run the tests.
 Therefore the image contains an eclipse and vncserver installation.
 
-## Build images
-
-### Prerequisites
-* Local installation of docker
-
-### Build all images
-* Simply call the script `build.sh` to build and tag the images in your local registry.
-
-### Troubleshooting
-The build process should fail if a command of the corresponding setup bash script fails. There are two possible reasons why this could happen:
-* A bug in a Dockerfile or script
-* One of the following external dependencies is not available:
-  * A docker image which is used as the basis for our images
-  * A uri which is defined in `src/uri_env.sh` is not reachable
-
-## Push image to Docker Hub
-### Prerequisites
-* Local installation of docker
-* You have a [Docker Hub account](https://hub.docker.com/)
-* Your Docker Hub account is part of the [saros organization](https://hub.docker.com/u/saros/dashboard/)
-* The image name is equal to the corresponding repository
-  * If this is not the case retag the image by `docker tag <old tag> <new tag>`.
-
-### Push process
-* Open bash
-* Log in to Docker Hub via the docker client
-  * `docker login`
-  * Enter user credentials
-* Push image to repository
-  * `docker push <image tag>`
-    * Example: `docker push saros/ci_build:0.2` 


### PR DESCRIPTION
* Removed the obsoleted documentation
* Described how an image can be published by
creating a git tag