### PR TITLE
[FIX][I] Use IntelliJ release with bundled JBR

### DIFF
--- a/src/uri_env.sh
+++ b/src/uri_env.sh
@@ -1,4 +1,4 @@
 export ECLIPSE_URI="https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/photon/R/eclipse-java-photon-R-linux-gtk-x86_64.tar.gz&r=1" \
-       INTELLIJ_URI="https://download.jetbrains.com/idea/ideaIC-2019.2.3-no-jbr.tar.gz" \
+       INTELLIJ_URI="https://download.jetbrains.com/idea/ideaIC-2019.2.3.tar.gz" \
        GRADLE_URI="https://services.gradle.org/distributions/gradle-4.10.1-bin.zip" \
        NODE_URI="https://nodejs.org/dist/v8.0.0/node-v8.0.0-linux-x64.tar.gz"


### PR DESCRIPTION
Use IntelliJ release with the bundled JetBrains Runtime Environment
(JBR) to avoid issues with the task 'buildSearchableOptions'.